### PR TITLE
Improve before/after layout

### DIFF
--- a/index.css
+++ b/index.css
@@ -1304,3 +1304,57 @@
   z-index: 1;
 }
 
+/* Before/After comparison styles */
+.before-after {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 40px 0;
+  border-radius: 8px;
+  overflow: hidden;
+  gap: 0;
+}
+
+.before-after .col {
+  flex: 1 1 300px;
+  padding: 2rem;
+}
+
+.before-after .without {
+  background: #f4f4f4;
+}
+
+.before-after .with {
+  background: #eaf8f1;
+}
+
+.before-after h3 {
+  margin-top: 0;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.before-after ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.before-after li {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.before-after .list-icon {
+  width: 36px;
+  height: 36px;
+  margin-right: 0.5rem;
+}
+
+@media (max-width: 600px) {
+  .before-after {
+    flex-direction: column;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -86,78 +86,28 @@
       <div class="u-clearfix u-sheet u-valign-top-lg u-valign-top-sm u-valign-top-xs u-sheet-1">
         <h2 class="u-align-left u-custom-font u-font-montserrat u-text u-text-1"> Our Services</h2>
         <p class="u-align-left u-custom-font u-font-lato u-text u-text-2"> We simplify your digital marketing and automation, so you can focus on growing your business.</p>
-        <h3 class="u-align-left u-custom-font u-font-montserrat u-text u-text-3">Without Sagvox</h3>
-        <div class="data-layout-selected u-clearfix u-expanded-width u-layout-wrap u-layout-wrap-1">
-          <div class="u-layout">
-            <div class="u-layout-row">
-              <div class="u-container-style u-layout-cell u-size-11 u-white u-layout-cell-1">
-                <div class="u-container-layout u-container-layout-1">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-1" src="images/Untitleddesign-5.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-2" src="images/Untitleddesign-6.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-3" src="images/Untitleddesign-7.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-4" src="images/ManualRepetitiveWork.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-5" src="images/BlindOptimization.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-6" src="images/LowVisibilityROI.png" alt="" data-image-width="501" data-image-height="501">
-                </div>
-              </div>
-              <div class="u-container-style u-custom-color-1 u-layout-cell u-size-20 u-layout-cell-2">
-                <div class="u-container-layout u-container-layout-2">
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-4"> Scattered Strategy</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-5"> Time-Consuming Execution</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-6">Technical Headaches</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-7">Manual &amp; Repetitive Work</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-8">Blind Optimization</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-9">Low Visibility &amp; ROI</p>
-                </div>
-              </div>
-              <div class="u-container-style u-custom-color-1 u-layout-cell u-size-29 u-layout-cell-3">
-                <div class="u-container-layout u-container-layout-3">
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-10">You’re unsure who to target, priorities are unclear.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-11">Campaigns take forever to build and don’t convert.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-12">Tools don’t talk to each other, landing pages break.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-13">Hours wasted on CRM, emails, spreadsheets.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-14">You can’t tell what’s working, just guessing.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-15">Your content gets lost and results stay low.</p>
-                </div>
-              </div>
-            </div>
+        <div class="before-after">
+          <div class="col without">
+            <h3 class="u-custom-font u-font-montserrat">Without Sagvox</h3>
+            <ul>
+              <li><img src="images/Untitleddesign-5.png" alt="" class="list-icon"> ❌ Scattered &amp; unclear strategy</li>
+              <li><img src="images/Untitleddesign-6.png" alt="" class="list-icon"> ❌ Slow campaigns that flop</li>
+              <li><img src="images/Untitleddesign-7.png" alt="" class="list-icon"> ❌ Tools don’t connect</li>
+              <li><img src="images/ManualRepetitiveWork.png" alt="" class="list-icon"> ❌ Wasted hours on busywork</li>
+              <li><img src="images/BlindOptimization.png" alt="" class="list-icon"> ❌ Guessing what works</li>
+              <li><img src="images/LowVisibilityROI.png" alt="" class="list-icon"> ❌ Low visibility &amp; results</li>
+            </ul>
           </div>
-        </div>
-        <h3 class="u-align-left u-custom-font u-font-montserrat u-text u-text-16">With Sagvox</h3>
-        <div class="data-layout-selected u-clearfix u-expanded-width u-layout-wrap u-layout-wrap-2" title="">
-          <div class="u-layout">
-            <div class="u-layout-row">
-              <div class="u-container-style u-layout-cell u-size-11 u-white u-layout-cell-4">
-                <div class="u-container-layout u-container-layout-4">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-7" src="images/DiagnosisStrategy.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-8" src="images/CampaignExecution.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-9" src="images/LandingPagesFunnels.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-10" src="images/Automation.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-11" src="images/ContinuousSupportOptimization.png" alt="" data-image-width="501" data-image-height="501">
-                  <img class="u-image u-image-contain u-image-default u-preserve-proportions u-image-12" src="images/DemandGenerationSEO.png" alt="" data-image-width="501" data-image-height="501">
-                </div>
-              </div>
-              <div class="u-container-style u-layout-cell u-shape-rectangle u-size-20 u-layout-cell-5">
-                <div class="u-container-layout u-container-layout-5">
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-17"> Diagnosis &amp; Strategy</h4>
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-18"> Campaign Execution</h4>
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-19"> Landing Pages &amp; Funnels</h4>
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-20"> Automation</h4>
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-21"> Continuous Optimization</h4>
-                  <h4 class="u-custom-font u-font-lato u-text u-text-default u-text-22"> Demand Gen&nbsp;&amp; SEO</h4>
-                </div>
-              </div>
-              <div class="u-container-style u-layout-cell u-shape-rectangle u-size-29 u-layout-cell-6">
-                <div class="u-container-layout u-container-layout-6">
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-23"> Clarity &amp; Confidence&nbsp;— Discovery, audits, roadmap.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-24"> Creativity &amp; Impact&nbsp;— Design, content, launch.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-25"> Simplicity &amp; Readiness&nbsp;— Pages and funnels done.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-26"> Efficiency &amp; Scalability&nbsp;— Smart workflows &amp; CRM.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-27"> Improvement &amp; Insights&nbsp;— Monthly fine-tuning.</p>
-                  <p class="u-custom-font u-font-lato u-text u-text-default u-text-28"> Visibility &amp; Growth&nbsp;— Content &amp; organic reach.</p>
-                </div>
-              </div>
-            </div>
+          <div class="col with">
+            <h3 class="u-custom-font u-font-montserrat">With Sagvox</h3>
+            <ul>
+              <li><img src="images/DiagnosisStrategy.png" alt="" class="list-icon"> ✅ Clear roadmap &amp; priorities</li>
+              <li><img src="images/CampaignExecution.png" alt="" class="list-icon"> ✅ Creative, high-impact launches</li>
+              <li><img src="images/LandingPagesFunnels.png" alt="" class="list-icon"> ✅ Seamless workflows &amp; CRM</li>
+              <li><img src="images/Automation.png" alt="" class="list-icon"> ✅ Automation that saves time</li>
+              <li><img src="images/ContinuousSupportOptimization.png" alt="" class="list-icon"> ✅ Data-driven optimization</li>
+              <li><img src="images/DemandGenerationSEO.png" alt="" class="list-icon"> ✅ Content that drives growth</li>
+            </ul>
           </div>
         </div>
         <p class="u-align-center u-custom-font u-font-lato u-text u-text-29"> Stop juggling. Start growing.</p>


### PR DESCRIPTION
## Summary
- redesign the Services section into a simple Before/After split
- apply new styling for comparison columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68741dd6bbf4832ca3e2196c37389989